### PR TITLE
Correct copy-paste gitch in return type annotation

### DIFF
--- a/content/posts/pydantic-with-third-party-types.md
+++ b/content/posts/pydantic-with-third-party-types.md
@@ -90,7 +90,7 @@ class WeekdayAnnotations(BaseModel):
     n: int | None = None
 
     @model_validator(mode="wrap")
-    def _validate(value, handler) -> relativedelta:
+    def _validate(value, handler) -> weekday:
         # if already dateutil._common.weekday instance, return it
         if isinstance(value, weekday):
             return value


### PR DESCRIPTION
Hi, thanks for this very helpful blog post!

Unless I'm mistaken, the `WeekdayAnnotations` model validator is returning a `weekday` type, not a `relativedelta`.